### PR TITLE
fix: exception not show correctly in profiler panel

### DIFF
--- a/src/EventListener/ApiExceptionListener.php
+++ b/src/EventListener/ApiExceptionListener.php
@@ -55,7 +55,7 @@ final class ApiExceptionListener
             $exception->getStatusCode() : Response::HTTP_INTERNAL_SERVER_ERROR;
 
         if (Response::HTTP_INTERNAL_SERVER_ERROR === $statusCode) {
-            $this->logger->error($exception);
+            $this->logger->error($exception->getMessage(), ['exception'=>$exception]);
 
             $response = $this->createInternalErrorResponse($statusCode, $exception);
 
@@ -107,3 +107,4 @@ final class ApiExceptionListener
         return $this->env === 'prod';
     }
 }
+


### PR DESCRIPTION
Change the error message from the following structure
![image](https://github.com/bugloos/error-response-bundle/assets/4004087/c24d83cc-cace-4d33-be83-11d245e2069a)
to the following structure
![image](https://github.com/bugloos/error-response-bundle/assets/4004087/9f95964d-4847-4faf-901a-b0838b8f8169)
